### PR TITLE
add markdown local links to rules in Rule Directory.md

### DIFF
--- a/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleListDocumentation.swift
@@ -43,19 +43,19 @@ public struct RuleListDocumentation {
             ## Default Rules
 
             \(defaultRuleDocumentations
-                .map { "* `\($0.ruleIdentifier)`: \($0.ruleName)" }
+                .map { "* `\($0.ruleIdentifier)`: [\($0.ruleName)](\($0.ruleIdentifier).md)" }
                 .joined(separator: "\n"))
 
             ## Opt-In Rules
 
             \(optInRuleDocumentations
-                .map { "* `\($0.ruleIdentifier)`: \($0.ruleName)" }
+                .map { "* `\($0.ruleIdentifier)`: [\($0.ruleName)](\($0.ruleIdentifier).md)" }
                 .joined(separator: "\n"))
 
             ## Analyzer Rules
 
             \(analyzerRuleDocumentations
-                .map { "* `\($0.ruleIdentifier)`: \($0.ruleName)" }
+                .map { "* `\($0.ruleIdentifier)`: [\($0.ruleName)](\($0.ruleIdentifier).md)" }
                 .joined(separator: "\n"))
 
             """


### PR DESCRIPTION
Generated docs index file (`Rule Directory.md`) places near rules `md` files, which allows us to make relative links and use docs in more convenient format

### Docs struct:
<img width="277" alt="docs-struct" src="https://user-images.githubusercontent.com/7829589/217759949-136ee55a-19fa-4ef6-a619-24e6db8985be.png">

### Demo:
| Before  | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/7829589/217760508-9ba8f921-c759-4ad4-8f92-8df0d2871316.mov">  | <video src="https://user-images.githubusercontent.com/7829589/217760552-d1b1ef1a-94f3-483e-b0f0-4fe29c1fec94.mov">|
